### PR TITLE
Fix ImportError when supersmoother is installed as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,10 @@ def read(path, encoding='utf-8'):
 
 
 def version(path):
+    """Obtain the packge version from a python file e.g. pkg/__init__.py
+
+    See <https://packaging.python.org/en/latest/single_source_version.html>.
+    """
     version_file = read(path)
     version_match = re.search(r"""^__version__ = ['"]([^'"]*)['"]""",
                               version_file, re.M)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,24 @@
+import io
+import os
+import re
+
 from distutils.core import setup
+
+
+def read(path, encoding='utf-8'):
+    path = os.path.join(os.path.dirname(__file__), path)
+    with io.open(path, encoding=encoding) as fp:
+        return fp.read()
+
+
+def version(path):
+    version_file = read(path)
+    version_match = re.search(r"""^__version__ = ['"]([^'"]*)['"]""",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
 
 DESCRIPTION = "Python implementation of Friedman's Supersmoother"
 LONG_DESCRIPTION = """
@@ -19,8 +39,7 @@ URL = 'http://github.com/jakevdp/supersmoother'
 DOWNLOAD_URL = 'http://github.com/jakevdp/supersmoother'
 LICENSE = 'BSD 3-clause'
 
-import supersmoother
-VERSION = supersmoother.__version__
+VERSION = version('supersmoother/__init__.py')
 
 setup(name=NAME,
       version=VERSION,


### PR DESCRIPTION
When other packages install supersmoother as one of their dependecncies it's not safe to import supersmoother during the install phase. This is because supersmoother's own dependencies might not be installed yet, e.g. numpy.

This change will fix the following error:

    $ pip install .[full]
    Processing /home/alex/src/pandashells
    Collecting numpy (from pandashells==0.1.4)
      Downloading numpy-1.9.2.tar.gz (4.0MB)
    ...
    Collecting supersmoother (from pandashells==0.1.4)
      Downloading supersmoother-0.3.1.tar.gz (572kB)
        100% |████████████████████████████████| 573kB 991kB/s
        Complete output from command python setup.py egg_info:
        Traceback (most recent call last):
          File "<string>", line 20, in <module>
          File "/tmp/pip-build-kYP8xD/supersmoother/setup.py", line 22, in <module>
            import supersmoother
          File "supersmoother/__init__.py", line 6, in <module>
            from .smoother import MovingAverageSmoother, LinearSmoother
          File "supersmoother/smoother.py", line 2, in <module>
            import numpy as np
        ImportError: No module named numpy

        ----------------------------------------
    Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-kYP8xD/supersmoother