### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is an efficient implementation of Friedman's SuperSmoother [1]
 algorithm in pure Python. It makes use of [numpy](http://numpy.org)
 for fast numerical computation.
 
-[![DOI](https://zenodo.org/badge/9372/jakevdp/supersmoother.svg)](http://dx.doi.org/10.5281/zenodo.14475)
+[![DOI](https://zenodo.org/badge/9372/jakevdp/supersmoother.svg)](https://doi.org/10.5281/zenodo.14475)
 [![version status](http://img.shields.io/pypi/v/supersmoother.svg?style=flat)](https://pypi.python.org/pypi/supersmoother)
 [![build status](http://img.shields.io/travis/jakevdp/supersmoother/master.svg?style=flat)](https://travis-ci.org/jakevdp/supersmoother)
 [![license](http://img.shields.io/badge/license-BSD-blue.svg?style=flat)](https://github.com/jakevdp/supersmoother/blob/master/LICENSE)
@@ -43,7 +43,7 @@ Authors
 Citing This Work
 ----------------
 If you use this code in an academic publication, please consider including a citation to our work.
-Citation information in a variety of formats can be found [on zenodo](http://dx.doi.org/10.5281/zenodo.14475).
+Citation information in a variety of formats can be found [on zenodo](https://doi.org/10.5281/zenodo.14475).
 
 References
 ----------

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -11,7 +11,7 @@ written in pure Python. It makes use of NumPy for fast numerical computations.
 
 This package was created by `Jake VanderPlas <http://www.vanderplas.com/>`_.
 If you use this package for a publication, please consider citing
-`the code <http://dx.doi.org/10.5281/zenodo.14475>`_.
+`the code <https://doi.org/10.5281/zenodo.14475>`_.
 
 For issues & contributions, see the source repository
 `on github <http://github.com/jakevdp/supersmoother/>`_.


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates all static DOI links.

Cheers!