### PR TITLE
Update for compatibility with modern packaging tooling.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,2 @@
 [metadata]
-description-file = README.md
-
-
-[bdist_wheel]
-universal = 1
+description_file = README.md

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ MAINTAINER = "Jake VanderPlas"
 MAINTAINER_EMAIL = "jakevdp@uw.edu"
 URL = 'http://github.com/jakevdp/supersmoother'
 DOWNLOAD_URL = 'http://github.com/jakevdp/supersmoother'
-LICENSE = 'BSD 3-clause'
 
 VERSION = version('supersmoother/__init__.py')
 
@@ -55,7 +54,6 @@ setup(name=NAME,
       maintainer_email=MAINTAINER_EMAIL,
       url=URL,
       download_url=DOWNLOAD_URL,
-      license=LICENSE,
       install_requires=["numpy"],
       tests_require=["scipy"],
       packages=['supersmoother',
@@ -65,10 +63,8 @@ setup(name=NAME,
         'Development Status :: 4 - Beta',
         'Environment :: Console',
         'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6'],
+        'Programming Language :: Python :: 3',
+      ],
      )


### PR DESCRIPTION
This patch implements minimal changes so that supersmoother stays installable with modern tooling:

- Indicate build-system in pyproject.toml.
- Don't use the deprecated description-file (README.md should be found automatically anyways).
- Remove the deprecated license metadata entries (the LICENSE file already provides the relevant legal info).
- Remove the deprecated bdist_wheel.universal entry.
- (Minimally update classifiers re: Python versions.)

Note: I realize that this package may not really be maintained anymore (though it actually still works just fine, and is useful to me), so I chose to go with a changeset as minimal as possible (to make `pip install` work).  If you prefer, I can also fully move everything to pyproject.toml, though that'll likely entail dropping compatibility with most older Python versions.