### PR TITLE
Convert to pytest.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,6 @@ htmlcov/
 .tox/
 .coverage
 .cache
-nosetests.xml
 coverage.xml
 
 # Translations

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ You can see these in the ``examples/`` directory, or view them statically
 
 Testing
 -------
-This code has full unit tests implemented in [nose](https://nose.readthedocs.org/en/latest/). With ``nose`` installed, you can run the test suite using
+This code has full unit tests implemented in [pytest](https://pytest.org). With ``pytest`` installed, you can run the test suite using
 ```
-$ nosetests supersmoother
+$ pytest
 ```
 The package is tested with Python versions 2.7, 3.4, 3.5, and 3.6.
 

--- a/supersmoother/tests/test_basic_smoothers.py
+++ b/supersmoother/tests/test_basic_smoothers.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division
 import numpy as np
 from numpy.testing import (assert_allclose, assert_array_less,
                            assert_equal, assert_raises)
+import pytest
 
 from .. import MovingAverageSmoother, LinearSmoother
 from ..smoother import Smoother
@@ -22,162 +23,131 @@ def make_linear(N=100, err=1E-6, rseed=None):
     return t, y, err
 
 
-def test_sine():
+@pytest.mark.parametrize("Model", [MovingAverageSmoother, LinearSmoother])
+@pytest.mark.parametrize("span, err", [(0.05, 0.005), (0.2, 0.01), (0.5, 0.1)])
+def test_sine(Model, span, err):
     t, y, dy = make_sine(N=100, err=0.05, rseed=0)
 
     tfit = np.linspace(1, 5.3, 50)
     ytrue = np.sin(tfit)
 
-    def check_model(Model, span, err):
-        model = Model(span).fit(t, y, dy)
-        yfit = model.predict(tfit)
-        obs_err = np.mean((yfit - ytrue) ** 2)
-        assert_array_less(obs_err, err)
-
-    spans = [0.05, 0.2, 0.5]
-    errs = [0.005, 0.01, 0.1]
-
-    for Model in [MovingAverageSmoother, LinearSmoother]:
-        for span, err in zip(spans, errs):
-            yield check_model, Model, span, err
+    model = Model(span).fit(t, y, dy)
+    yfit = model.predict(tfit)
+    obs_err = np.mean((yfit - ytrue) ** 2)
+    assert_array_less(obs_err, err)
 
 
-def test_sine_cv():
+@pytest.mark.parametrize("Model", [MovingAverageSmoother, LinearSmoother])
+@pytest.mark.parametrize("span, err", [(0.05, 0.005), (0.2, 0.01), (0.5, 0.1)])
+def test_sine_cv(Model, span, err):
     t, y, dy = make_sine(N=100, err=0.05, rseed=0)
     ytrue = np.sin(np.sort(t)[1:-1])
 
-    def check_model(Model, span, err):
-        model = Model(span).fit(t, y, dy)
-        yfit = model.cv_values()[1:-1]
-        obs_err = np.mean((yfit - ytrue) ** 2)
-        assert_array_less(obs_err, err)
-
-    spans = [0.05, 0.2, 0.5]
-    errs = [0.005, 0.02, 0.1]
-
-    for Model in [MovingAverageSmoother, LinearSmoother]:
-        for span, err in zip(spans, errs):
-            yield check_model, Model, span, err
+    model = Model(span).fit(t, y, dy)
+    yfit = model.cv_values()[1:-1]
+    obs_err = np.mean((yfit - ytrue) ** 2)
+    assert_array_less(obs_err, err)
 
 
-def test_line_linear():
+@pytest.mark.parametrize("span", [0.05, 0.2, 0.5])
+def test_line_linear(span):
     t, y, dy = make_linear(rseed=0, err=1E-6)
     tfit = np.linspace(0, 10, 40)
 
-    def check_model(span):
-        model = LinearSmoother(span).fit(t, y, dy)
-        yfit = model.predict(tfit)
-        assert_allclose(tfit, yfit, atol=1E-5)
-
-    for span in [0.05, 0.2, 0.5]:
-        yield check_model, span
+    model = LinearSmoother(span).fit(t, y, dy)
+    yfit = model.predict(tfit)
+    assert_allclose(tfit, yfit, atol=1E-5)
 
 
-
-def test_variable_sine_predict():
+@pytest.mark.parametrize("Model", [MovingAverageSmoother, LinearSmoother])
+@pytest.mark.parametrize("span", [0.05, 0.2, 0.5])
+def test_variable_sine_predict(Model, span):
     t, y, dy = make_sine(N=100, err=0.05, rseed=0)
 
     tfit = np.linspace(1, 5.3, 50)
     ytrue = np.sin(tfit)
 
-    def check_model(Model, span):
-        model1 = Model(span * np.ones_like(t))
-        model2 = Model(span)
-        assert_allclose(model1.fit(t, y, dy).predict(tfit),
-                        model2.fit(t, y, dy).predict(tfit))
-
-    for Model in [MovingAverageSmoother, LinearSmoother]:
-        for span in [0.05, 0.2, 0.5]:
-            yield check_model, Model, span
+    model1 = Model(span * np.ones_like(t))
+    model2 = Model(span)
+    assert_allclose(model1.fit(t, y, dy).predict(tfit),
+                    model2.fit(t, y, dy).predict(tfit))
 
 
-def test_variable_sine_crossval():
+@pytest.mark.parametrize("Model", [MovingAverageSmoother, LinearSmoother])
+@pytest.mark.parametrize("span", [0.05, 0.2, 0.5])
+def test_variable_sine_crossval(Model, span):
     t, y, dy = make_sine(N=100, err=0.05, rseed=0)
 
     tfit = np.linspace(1, 5.3, 50)
     ytrue = np.sin(tfit)
 
-    def check_model(Model, span):
-        model1 = Model(span * np.ones_like(t))
-        model2 = Model(span)
-        assert_allclose(model1.fit(t, y, dy).cv_values(),
-                        model2.fit(t, y, dy).cv_values())
-
-    for Model in [MovingAverageSmoother, LinearSmoother]:
-        for span in [0.05, 0.2, 0.5]:
-            yield check_model, Model, span
+    model1 = Model(span * np.ones_like(t))
+    model2 = Model(span)
+    assert_allclose(model1.fit(t, y, dy).cv_values(),
+                    model2.fit(t, y, dy).cv_values())
 
 
-def test_func_span_const():
+@pytest.mark.parametrize("Model", [MovingAverageSmoother, LinearSmoother])
+@pytest.mark.parametrize("span", [0.05, 0.2, 0.5])
+def test_func_span_const(Model, span):
     t, y, dy = make_sine(N=100, err=0.05, rseed=0)
 
-    def check_model(Model, span, spanfunc):
-        model1 = Model(span)
-        model2 = Model(spanfunc)
-        assert_allclose(model1.fit(t, y, dy).predict(t),
-                        model2.fit(t, y, dy).predict(t))
+    spanfunc = lambda t, span=span: span * np.ones_like(t)
 
-    for Model in [MovingAverageSmoother, LinearSmoother]:
-        for span in [0.05, 0.2, 0.5]:
-            spanfunc = lambda t, span=span: span * np.ones_like(t)
-            yield check_model, Model, span, spanfunc
+    model1 = Model(span)
+    model2 = Model(spanfunc)
+    assert_allclose(model1.fit(t, y, dy).predict(t),
+                    model2.fit(t, y, dy).predict(t))
 
 
-def test_func_span_variable():
+@pytest.mark.parametrize("Model", [MovingAverageSmoother, LinearSmoother])
+def test_func_span_variable(Model):
     t, y, dy = make_sine(N=100, err=0.05, rseed=0)
 
     spanfunc = lambda t, tmax=t.max(): 0.5 + 0.05 * t / tmax
     span = spanfunc(t)
 
-    def check_model(Model, span, spanfunc):
-        model1 = Model(span)
-        model2 = Model(spanfunc)
-        assert_allclose(model1.fit(t, y, dy).predict(t),
-                        model2.fit(t, y, dy).predict(t))
-
-    for Model in [MovingAverageSmoother, LinearSmoother]:
-        yield check_model, Model, span, spanfunc
+    model1 = Model(span)
+    model2 = Model(spanfunc)
+    assert_allclose(model1.fit(t, y, dy).predict(t),
+                    model2.fit(t, y, dy).predict(t))
 
 
-def test_cv_interface():
+@pytest.mark.parametrize("Model", [MovingAverageSmoother, LinearSmoother])
+@pytest.mark.parametrize("cv", [True, False])
+@pytest.mark.parametrize("skip_endpoints", [True, False])
+def test_cv_interface(Model, cv, skip_endpoints):
     t, y, dy = make_sine(N=100, err=0.05, rseed=0)
     span = 0.2
 
-    def check_model(Model, span, cv, skip_endpoints):
-        model = Model(span).fit(t, y, dy)
-        cv_values = model.cv_values(cv=cv)
-        cv_residuals = (model.y - cv_values) / model.dy
-        if skip_endpoints:
-            cv_error = np.mean(abs(cv_residuals[1:-1]))
-        else:
-            cv_error = np.mean(abs(cv_residuals))
+    model = Model(span).fit(t, y, dy)
+    cv_values = model.cv_values(cv=cv)
+    cv_residuals = (model.y - cv_values) / model.dy
+    if skip_endpoints:
+        cv_error = np.mean(abs(cv_residuals[1:-1]))
+    else:
+        cv_error = np.mean(abs(cv_residuals))
 
-        assert_allclose(cv_residuals,
-                        model.cv_residuals(cv=cv))
-        assert_allclose(cv_error,
-                        model.cv_error(cv=cv, skip_endpoints=skip_endpoints))
-
-    for Model in [MovingAverageSmoother, LinearSmoother]:
-        for cv in [True, False]:
-            for skip_endpoints in [True, False]:
-                yield check_model, Model, span, cv, skip_endpoints
+    assert_allclose(cv_residuals,
+                    model.cv_residuals(cv=cv))
+    assert_allclose(cv_error,
+                    model.cv_error(cv=cv, skip_endpoints=skip_endpoints))
 
 
-def test_span_extremes():
+@pytest.mark.parametrize("Model", [MovingAverageSmoother, LinearSmoother])
+@pytest.mark.parametrize("span", (-1, 0, 1, 2))
+def test_span_extremes(Model, span):
     """Test models with extreme values of spans"""
     t, y, dy = make_sine(10, err=0.05, rseed=0)
 
-    def check_model(Model, span):
-        model1 = Model(span).fit(t, y, dy)
-        model2 = Model(span + np.zeros_like(t)).fit(t, y, dy)
-        assert_allclose(model1.cv_values(False), model2.cv_values(False))
-
-    for Model in [MovingAverageSmoother, LinearSmoother]:
-        for span in (-1, 0, 1, 2):
-            yield check_model, Model, span
+    model1 = Model(span).fit(t, y, dy)
+    model2 = Model(span + np.zeros_like(t)).fit(t, y, dy)
+    assert_allclose(model1.cv_values(False), model2.cv_values(False))
     
 
-def test_periodic():
+@pytest.mark.parametrize("Model", [MovingAverageSmoother, LinearSmoother])
+@pytest.mark.parametrize("span", [3, 4, 5])
+def test_periodic(Model, span):
     rng = np.random.RandomState(0)
     N = 10
     period = 1
@@ -187,19 +157,13 @@ def test_periodic():
     t_folded = np.concatenate([-period + t, t, t + period])
     y_folded = np.concatenate([y, y, y])
 
-    def check_model(Model, span):
-        model1 = Model(span / len(t_folded), period=None)
-        model2 = Model(span / len(t), period=period)
+    model1 = Model(span / len(t_folded), period=None)
+    model2 = Model(span / len(t), period=period)
 
-        model1.fit(t_folded, y_folded)
-        model2.fit(t, y)
+    model1.fit(t_folded, y_folded)
+    model2.fit(t, y)
 
-        assert_allclose(model1.predict(t), model2.predict(t))
-    
-
-    for Model in [MovingAverageSmoother, LinearSmoother]:
-        for span in [3, 4, 5]:
-            yield check_model, Model, span
+    assert_allclose(model1.predict(t), model2.predict(t))
 
 
 def test_baseclass():

--- a/supersmoother/tests/test_supersmoother.py
+++ b/supersmoother/tests/test_supersmoother.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division
 
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_less, assert_equal
+import pytest
 
 from .. import SuperSmoother, LinearSmoother
 
@@ -71,24 +72,20 @@ def test_bass_enhancement_10():
     assert_allclose(model1.predict(t), model2.predict(t), atol=1E-1)
 
 
-
-def test_cv_interface():
+@pytest.mark.parametrize("cv", [True, False])
+@pytest.mark.parametrize("skip_endpoints", [True, False])
+def test_cv_interface(cv, skip_endpoints):
     t, y, dy = make_sine(N=100, err=0.05, rseed=0)
     model = SuperSmoother().fit(t, y, dy)
 
-    def check_model(cv, skip_endpoints):
-        cv_values = model.cv_values(cv=cv)
-        cv_residuals = (model.y - cv_values) / model.dy
-        if skip_endpoints:
-            cv_error = np.mean(abs(cv_residuals[1:-1]))
-        else:
-            cv_error = np.mean(abs(cv_residuals))
+    cv_values = model.cv_values(cv=cv)
+    cv_residuals = (model.y - cv_values) / model.dy
+    if skip_endpoints:
+        cv_error = np.mean(abs(cv_residuals[1:-1]))
+    else:
+        cv_error = np.mean(abs(cv_residuals))
 
-        assert_allclose(cv_residuals,
-                        model.cv_residuals(cv=cv))
-        assert_allclose(cv_error,
-                        model.cv_error(cv=cv, skip_endpoints=skip_endpoints))
-
-    for cv in [True, False]:
-        for skip_endpoints in [True, False]:
-            yield check_model, cv, skip_endpoints
+    assert_allclose(cv_residuals,
+                    model.cv_residuals(cv=cv))
+    assert_allclose(cv_error,
+                    model.cv_error(cv=cv, skip_endpoints=skip_endpoints))

--- a/supersmoother/tests/test_utils.py
+++ b/supersmoother/tests/test_utils.py
@@ -4,6 +4,7 @@ from ..utils import windowed_sum, windowed_sum_slow
 
 import numpy as np
 from numpy.testing import assert_allclose, assert_, assert_equal, assert_raises
+import pytest
 
 
 def test_iterable():
@@ -13,21 +14,18 @@ def test_iterable():
     assert_(not utils.iterable(y))
 
 
-def test_multiinterp(rseed=0, N=100):
+@pytest.mark.parametrize("k", [3, 4, 5])
+def test_multiinterp(k, rseed=0, N=100):
     """Test of the multinterp function"""
     rng = np.random.RandomState(rseed)
 
-    def check_match(k):
-        x = np.sort(rng.rand(k))
-        y = rng.rand(k, N)
-        xquery = rng.rand(N)
+    x = np.sort(rng.rand(k))
+    y = rng.rand(k, N)
+    xquery = rng.rand(N)
 
-        res1 = utils.multinterp(x, y, xquery, slow=False)
-        res2 = utils.multinterp(x, y, xquery, slow=True)
-        assert_allclose(res1, res2)
-
-    for k in 3, 4, 5:
-        yield check_match, k
+    res1 = utils.multinterp(x, y, xquery, slow=False)
+    res2 = utils.multinterp(x, y, xquery, slow=True)
+    assert_allclose(res1, res2)
 
 
 def test_setattr_context():
@@ -110,158 +108,142 @@ def _variable_span_sum(a, span, subtract_mid=False):
     return np.asarray([results[j][i] for i, j in enumerate(inv)])
 
 
-def test_windowed_sum_simple():
+@pytest.mark.parametrize("wsum", [windowed_sum, windowed_sum_slow])
+@pytest.mark.parametrize("N", range(2, 6))
+@pytest.mark.parametrize("span", range(1, 7))
+def test_windowed_sum_simple(wsum, N, span):
     #"""windowed sum in the simplest case"""
     rng = np.random.RandomState(0)
-        
-    def check_results(wsum, N, span):
-        a = rng.rand(N)
-        assert_allclose([_fixed_span_sum(a, span),
-                         _fixed_span_sum(a ** 2, span)],
-                        wsum([a, a ** 2], span))
 
-    for wsum in [windowed_sum, windowed_sum_slow]:
-        for N in range(2, 6):
-            for span in range(1, 7):
-                yield check_results, wsum, N, span
+    a = rng.rand(N)
+    assert_allclose([_fixed_span_sum(a, span),
+                     _fixed_span_sum(a ** 2, span)],
+                    wsum([a, a ** 2], span))
 
 
-def test_windowed_sum_with_t():
+@pytest.mark.parametrize("wsum", [windowed_sum, windowed_sum_slow])
+@pytest.mark.parametrize("N", range(2, 6))
+@pytest.mark.parametrize("span", range(1, 7))
+def test_windowed_sum_with_t(wsum, N, span):
     #"""windowed sum with powers of t"""
     rng = np.random.RandomState(0)
-        
-    def check_results(wsum, N, span):
-        a = rng.rand(N)
-        t = np.sort(rng.rand(N))
-        assert_allclose([_fixed_span_sum(a, span),
-                         _fixed_span_sum(a * t, span)],
-                        wsum([a, a], span, t=t, tpowers=[0, 1]))
 
-    for wsum in [windowed_sum, windowed_sum_slow]:
-        for N in range(2, 6):
-            for span in range(1, 7):
-                yield check_results, wsum, N, span
+    a = rng.rand(N)
+    t = np.sort(rng.rand(N))
+    assert_allclose([_fixed_span_sum(a, span),
+                     _fixed_span_sum(a * t, span)],
+                    wsum([a, a], span, t=t, tpowers=[0, 1]))
 
 
-def test_windowed_sum_varspan():
+@pytest.mark.parametrize("wsum", [windowed_sum, windowed_sum_slow])
+@pytest.mark.parametrize("N", range(2, 6))
+def test_windowed_sum_varspan(wsum, N):
     #"""windowed sum with a variable span"""
     rng = np.random.RandomState(0)
-        
-    def check_results(wsum, N):
-        a = rng.rand(N)
-        span = rng.randint(1, 5, N)
-        assert_allclose([_variable_span_sum(a, span),
-                         _variable_span_sum(a ** 2, span)],
-                        wsum([a, a ** 2], span))
 
-    for wsum in [windowed_sum, windowed_sum_slow]:
-        for N in range(2, 6):
-            yield check_results, wsum, N
+    a = rng.rand(N)
+    span = rng.randint(1, 5, N)
+    assert_allclose([_variable_span_sum(a, span),
+                     _variable_span_sum(a ** 2, span)],
+                    wsum([a, a ** 2], span))
 
 
-def test_windowed_sum_with_period():
+@pytest.mark.parametrize("wsum", [windowed_sum, windowed_sum_slow])
+@pytest.mark.parametrize("N", range(4, 6))
+@pytest.mark.parametrize("span", range(1, 7))
+@pytest.mark.parametrize("tpowers", [(0, 1), (0, 1, 2)])
+def test_windowed_sum_with_period(wsum, N, span, tpowers):
     #"""windowed sum with period"""
     rng = np.random.RandomState(0)
-        
-    def check_results(wsum, N, span, tpowers, period=0.6):
-        a = rng.rand(N)
-        t = np.sort(period * rng.rand(N))
 
-        # find the periodic result straightforwardly by concatenating arrays
-        a_all = np.concatenate([a for i in range(6)])
-        t_all = np.concatenate([t + i * period for i in range(-3, 3)])
+    period = 0.6
+    a = rng.rand(N)
+    t = np.sort(period * rng.rand(N))
 
-        res1 = wsum(len(tpowers) * [a_all], span, t=t_all,
-                    tpowers=tpowers, period=None)
-        res1 = [res[3 * N: 4 * N] for res in res1]
-        res2 = wsum(len(tpowers) * [a], span, t=t,
-                    tpowers=tpowers, period=period)
-        assert_allclose(res1, res2)
+    # find the periodic result straightforwardly by concatenating arrays
+    a_all = np.concatenate([a for i in range(6)])
+    t_all = np.concatenate([t + i * period for i in range(-3, 3)])
 
-    for wsum in [windowed_sum, windowed_sum_slow]:
-        for N in range(4, 7):
-            for span in range(1, 7):
-                for tpowers in [(0, 1), (0, 1, 2)]:
-                    yield check_results, wsum, N, span, tpowers
-    
+    res1 = wsum(len(tpowers) * [a_all], span, t=t_all,
+                tpowers=tpowers, period=None)
+    res1 = [res[3 * N: 4 * N] for res in res1]
+    res2 = wsum(len(tpowers) * [a], span, t=t,
+                tpowers=tpowers, period=period)
+    assert_allclose(res1, res2)
 
-def test_windowed_sum_with_indices():
+
+@pytest.mark.parametrize("wsum", [windowed_sum, windowed_sum_slow])
+@pytest.mark.parametrize("N", range(4, 6))
+@pytest.mark.parametrize("span", range(1, 7))
+def test_windowed_sum_with_indices(wsum, N, span):
     #"""windowed sum with indices"""
     rng = np.random.RandomState(0)
-        
-    def check_results(wsum, N, span):
-        ind = rng.randint(0, N, 4)
-        a = rng.rand(N)
-        t = np.sort(rng.rand(N))
 
-        res1 = wsum([a, a], span, t=t, tpowers=[0, 1])
-        res1 = [res[ind] for res in res1]
-        res2 = wsum([a, a], span, t=t, tpowers=[0, 1],
-                                 indices=ind)
-        
-        assert_allclose(res1, res2)
+    ind = rng.randint(0, N, 4)
+    a = rng.rand(N)
+    t = np.sort(rng.rand(N))
 
-    for wsum in [windowed_sum, windowed_sum_slow]:
-        for N in range(4, 6):
-            for span in range(1, 7):
-                yield check_results, wsum, N, span
+    res1 = wsum([a, a], span, t=t, tpowers=[0, 1])
+    res1 = [res[ind] for res in res1]
+    res2 = wsum([a, a], span, t=t, tpowers=[0, 1],
+                indices=ind)
+
+    assert_allclose(res1, res2)
 
 
-def test_windowed_sum_subtract_mid():
+@pytest.mark.parametrize("wsum", [windowed_sum, windowed_sum_slow])
+@pytest.mark.parametrize("N", range(2, 6))
+@pytest.mark.parametrize("span", range(1, 7))
+def test_windowed_sum_subtract_mid(wsum, N, span):
     #"""windowed sum, subtracting the middle item"""
     rng = np.random.RandomState(0)
-        
-    def check_results(wsum, N, span):
-        a = rng.rand(N)
-        t = np.sort(rng.rand(N))
-        assert_allclose([_fixed_span_sum(a, span, subtract_mid=True),
-                         _fixed_span_sum(a * t, span, subtract_mid=True)],
-                        wsum([a, a], span, t=t, tpowers=[0, 1],
-                             subtract_mid=True))
 
-    for wsum in [windowed_sum, windowed_sum_slow]:
-        for N in range(2, 6):
-            for span in range(1, 7):
-                yield check_results, wsum, N, span
+    a = rng.rand(N)
+    t = np.sort(rng.rand(N))
+    assert_allclose([_fixed_span_sum(a, span, subtract_mid=True),
+                     _fixed_span_sum(a * t, span, subtract_mid=True)],
+                    wsum([a, a], span, t=t, tpowers=[0, 1],
+                         subtract_mid=True))
 
 
-def test_windowed_sum_fast_vs_slow():
+_rng = np.random.RandomState(0)
+@pytest.mark.parametrize("N, span, indices", [
+    (N, span, indices)
+    for N in [3, 5, 7]
+    for span in [3, 5, _rng.randint(2, 5, N)]
+    for indices in [None, _rng.randint(0, N, N)]
+])
+@pytest.mark.parametrize("subtract_mid", [True, False])
+@pytest.mark.parametrize("tpowers", [0, (0, 1)])
+@pytest.mark.parametrize("period", (0.6, None))
+@pytest.mark.parametrize("use_t", [True, False])
+def test_windowed_sum_fast_vs_slow(N, span, indices, subtract_mid,
+                                   tpowers, period, use_t):
     #"""Test fast vs slow windowed sum for many combinations of parameters"""
     rng = np.random.RandomState(0)
-        
-    def check_results(N, span, indices, subtract_mid,
-                      tpowers, period, use_t):
-        a = rng.rand(N)
-        t = np.sort(rng.rand(N))
-        if period:
-            t *= period
 
-        if np.asarray(tpowers).size == 1:
-            arrs = [a]
-        else:
-            arrs = len(tpowers) * [a]
+    if period and not use_t:
+        return
 
-        if not use_t:
-            t = None
+    a = rng.rand(N)
+    t = np.sort(rng.rand(N))
+    if period:
+        t *= period
 
-        res1 = windowed_sum_slow(arrs, span, t=t, subtract_mid=subtract_mid,
-                                 indices=indices, tpowers=tpowers,
-                                 period=period)
-        res2 = windowed_sum(arrs, span, t=t, subtract_mid=subtract_mid,
-                            indices=indices, tpowers=tpowers, period=period)
-        assert_allclose(res1, res2)
+    if np.asarray(tpowers).size == 1:
+        arrs = [a]
+    else:
+        arrs = len(tpowers) * [a]
 
-    for N in [3, 5, 7]:
-        for span in [3, 5, rng.randint(2, 5, N)]:
-            for indices in [None, rng.randint(0, N, N)]:
-                for subtract_mid in [True, False]:
-                    for tpowers in [0, (0, 1)]:
-                        for period in (0.6, None):
-                            for use_t in [True, False]:
-                                if period and not use_t:
-                                    continue
-                                yield (check_results, N, span, indices,
-                                       subtract_mid, tpowers, period, use_t)
+    if not use_t:
+        t = None
+
+    res1 = windowed_sum_slow(arrs, span, t=t, subtract_mid=subtract_mid,
+                                indices=indices, tpowers=tpowers,
+                                period=period)
+    res2 = windowed_sum(arrs, span, t=t, subtract_mid=subtract_mid,
+                        indices=indices, tpowers=tpowers, period=period)
+    assert_allclose(res1, res2)
 
 
 def test_windowed_sum_bad_args(N=10):
@@ -287,7 +269,7 @@ def test_windowed_sum_period_zero(N=10):
     rng = np.random.RandomState(0)
     a = rng.rand(N)
     t = np.sort(0.6 * rng.rand(N))
-        
+
     def check_results(wsum, span=3):
         res1 = wsum(arrays=[a], span=3, tpowers=[0], period=None)
         res2 = wsum(arrays=[a], span=3, tpowers=[0], period=0)


### PR DESCRIPTION
Make test suite pytest compatible (essentially by rewriting yield-tests to use pytest.parametrize).
test_basic_smoothers.py::test_sine_cv[0.2-0.01-MovingAverageSmoother] does seem to be failing legitimately, though?