### PR TITLE
Add CI job for building wheels and source distributions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  release:  # trigger on published release
+    types:
+      - published
+
+permissions: {}
+
+jobs:
+  build:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+        with:
+          persist-credentials: false
+      - run: pipx run build
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: build-artifacts
+          path: dist/
+
+  download_and_list_artifacts:
+    # This is useful for debugging problems with the wheels and source distributions.
+    name: Download and list artifacts
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0  # v5.0.0
+        with:
+          name: build-artifacts
+          path: dist/
+      - name: List files
+        run: ls -l dist/
+
+  upload_to_pypi:
+    # This publishes to PyPI only in the case of a published release.
+    if: github.event_name == 'release' && github.event.action == 'published'
+    name: Release & Upload to PyPI
+    needs: [build]
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0  # v5.0.0
+        with:
+          name: build-artifacts
+          path: dist/
+      - name: List files
+        run: ls -l dist/
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # v1.13.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ dev = [
 requires = ["setuptools>=61"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools]
+packages = ["supersmoother"]
+
 [tool.setuptools.dynamic]
 version = {attr = "supersmoother.__version__"}
 


### PR DESCRIPTION
Also a stub for PyPI release (though we can't use this until I set up trusted publishing)