### PR TITLE
remove pytest-xdist dependency.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,4 +70,4 @@ jobs:
           python -m pip install .[dev]
       - name: Run tests
         run: |
-          python -m pytest -n auto
+          python -m pytest supersmoother

--- a/README.md
+++ b/README.md
@@ -31,10 +31,15 @@ You can see these in the `examples/` directory, or view them statically
 
 ## Testing
 This code has full unit tests implemented using [pytest](https://pytest.org).
-They can be run as follows from the source directory:
+To install the latest release and run its tests, use:
+```
+$ pip install supersmoother[dev]
+$ pytest --pyargs supersmoother
+```
+To install from source and run the tests from within the source directory, use:
 ```
 $ pip install .[dev]
-$ pytest -n auto supersmoother
+$ pytest supersmoother
 ```
 The package is tested with Python versions 3.10 through 3.14.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ repository = "https://github.com/jakevdp/supersmoother"
 [project.optional-dependencies]
 dev = [
     "pytest",
-    "pytest-xdist",
     "scipy",
 ]
 


### PR DESCRIPTION
The tests run fast enough that adding a dependency for parallelization is not worthwhile.