### PR TITLE
Fix minimal span.

### DIFF
--- a/supersmoother/tests/test_supersmoother.py
+++ b/supersmoother/tests/test_supersmoother.py
@@ -19,8 +19,9 @@ def make_linear(N=100, err=1E-6, rseed=None):
     return t, y, err
 
 
-def test_sine():
-    t, y, dy = make_sine(N=100, err=0.05, rseed=0)
+@pytest.mark.parametrize("N", [80, 100])
+def test_sine(N):
+    t, y, dy = make_sine(N=N, err=0.05, rseed=0)
 
     tfit = np.linspace(1, 5.3, 50)
     ytrue = np.sin(tfit)
@@ -31,8 +32,9 @@ def test_sine():
     assert_array_less(obs_err, 0.001)
 
 
-def test_sine_period():
-    t, y, dy = make_sine(N=100, err=0.05, rseed=0, n_periods=3)
+@pytest.mark.parametrize("N", [80, 100])
+def test_sine_period(N):
+    t, y, dy = make_sine(N=N, err=0.05, rseed=0, n_periods=3)
 
     tfit = np.linspace(-5, 5, 50)
     ytrue = np.sin(tfit)

--- a/supersmoother/utils.py
+++ b/supersmoother/utils.py
@@ -105,7 +105,10 @@ def _prep_smooth(
     elif span is None:
         raise ValueError("Must specify either span_out or span")
     else:
-        indices = None
+        indices = np.arange(len(t))
+
+    if not period:
+        indices = np.clip(indices, span // 2, len(t) - span // 2)
 
     assert span is not None
 


### PR DESCRIPTION
Try e.g. `SuperSmoother().fit(np.arange(80), np.random.rand(80))` (or anything such that the lowest span (here 0.05*80) is less than 5), which would previously result in a ValueError.

At the edges, the span should be non-centered so that the same number of points are kept.  (This is mentioned in Friedman's paper on page 4: "Near the boundaries, it is, of course, not possible to keep N symmetric.") Do so by preventing the indices of the span centers from getting too close to the edges.

Without this patch, a minimum span of 3 can become a span of only 2 points at the edge; after removing the center (for cross-validation) only one point is left and fit to a line raises an error.

Non-centered spans are also used elsewhere, e.g. in `savgol_filter(..., mode="interp")`.