### PR TITLE
Ensure spans are odd, so that they can be centered.

### DIFF
--- a/supersmoother/smoother.py
+++ b/supersmoother/smoother.py
@@ -122,7 +122,9 @@ class SpannedSmoother(Smoother):
         else:
             spanint = np.asarray(self.span) * len(self.t)
 
-        return np.clip(spanint, 3, None)
+        # ensure spanint is an odd integer >= 3.
+        spanint = np.clip(spanint.astype(int), 3, None)
+        return np.where(spanint % 2, spanint, spanint + 1)
 
     def _predict(self, t: ArrayLike) -> np.ndarray:
         if callable(self.span):

--- a/supersmoother/windowed_sum.py
+++ b/supersmoother/windowed_sum.py
@@ -42,7 +42,9 @@ def windowed_sum_slow(arrays: Sequence[ArrayLike],
     arrays : tuple of ndarrays
         arrays containing the windowed sum of each input array
     """
-    span = np.asarray(span, dtype=int)
+    span = np.asarray(span)
+    if not np.issubdtype(span.dtype, np.integer):
+        raise TypeError("span values must be integral")
     if not np.all(span > 0):
         raise ValueError("span values must be positive")
 
@@ -127,7 +129,9 @@ def windowed_sum(arrays: Sequence[ArrayLike],
     arrays : tuple of ndarrays
         arrays containing the windowed sum of each input array
     """
-    span = np.asarray(span, dtype=int)
+    span = np.asarray(span)
+    if not np.issubdtype(span.dtype, np.integer):
+        raise TypeError("span values must be integral")
     if not np.all(span > 0):
         raise ValueError("span values must be positive")
 


### PR DESCRIPTION
Even spans are non-centered and have non-zero phase.  Friedman assumed odd spans (at the very top of page 4).

This patch makes it natural to also immediately cast spans to integers, which allow removing the casts later on.